### PR TITLE
added __getitem__ for iterable behavior

### DIFF
--- a/adafruit_fancyled/adafruit_fancyled.py
+++ b/adafruit_fancyled/adafruit_fancyled.py
@@ -120,11 +120,11 @@ class CRGB(object):
 
     def __getitem__(self, key):
         """Retrieve red, green or blue value as iterable."""
-        if key is 0:
+        if key == 0:
             return self.red
-        elif key is 1:
+        elif key == 1:
             return self.green
-        elif key is 2:
+        elif key == 2:
             return self.blue
         else:
             raise IndexError
@@ -185,11 +185,11 @@ class CHSV(object):
 
     def __getitem__(self, key):
         """Retrieve hue, saturation or value as iterable."""
-        if key is 0:
+        if key == 0:
             return self.hue
-        elif key is 1:
+        elif key == 1:
             return self.saturation
-        elif key is 2:
+        elif key == 2:
             return self.value
         else:
             raise IndexError

--- a/adafruit_fancyled/adafruit_fancyled.py
+++ b/adafruit_fancyled/adafruit_fancyled.py
@@ -114,6 +114,21 @@ class CRGB(object):
     def __str__(self):
         return "(%s, %s, %s)" % (self.red, self.green, self.blue)
 
+    def __len__(self):
+        """Retrieve total number of color-parts available."""
+        return 3
+
+    def __getitem__(self, key):
+        """Retrieve red, green or blue value as iterable."""
+        if key is 0:
+            return self.red
+        elif key is 1:
+            return self.green
+        elif key is 2:
+            return self.blue
+        else:
+            raise IndexError
+
     def pack(self):
         """'Pack' a `CRGB` color into a 24-bit RGB integer.
 
@@ -163,6 +178,21 @@ class CHSV(object):
 
     def __str__(self):
         return "(%s, %s, %s)" % (self.hue, self.saturation, self.value)
+
+    def __len__(self):
+        """Retrieve total number of 'color-parts' available."""
+        return 3
+
+    def __getitem__(self, key):
+        """Retrieve hue, saturation or value as iterable."""
+        if key is 0:
+            return self.hue
+        elif key is 1:
+            return self.saturation
+        elif key is 2:
+            return self.value
+        else:
+            raise IndexError
 
     def pack(self):
         """'Pack' a `CHSV` color into a 24-bit RGB integer.


### PR DESCRIPTION
i added __getitem__ and __len__ magic functions to the CRGB and CHSV classes.
this way the get iterable and you can access the color-parts in list style.
so for other classes its easier to access the content in the same form as a plain list or tuple.

let me know what you think of this.

this idea came to my mind as i implemented the [TLC5957 driver](https://github.com/s-light/slight_CircuitPython_TLC5957)