### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_fancyled/adafruit_fancyled.py
+++ b/adafruit_fancyled/adafruit_fancyled.py
@@ -180,6 +180,7 @@ class CHSV:
     HSV->RGB->HSV translations won't have the same input and output.
     """
 
+    # pylint: disable=invalid-name
     def __init__(self, h, s=1.0, v=1.0):
         if isinstance(h, float):
             self.hue = h  # Don't clamp! Hue can wrap around forever.


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
************* Module adafruit_fancyled.adafruit_fancyled
Error: adafruit_fancyled/adafruit_fancyled.py:183:23: C0103: Argument name "h" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: adafruit_fancyled/adafruit_fancyled.py:183:26: C0103: Argument name "s" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: adafruit_fancyled/adafruit_fancyled.py:183:33: C0103: Argument name "v" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
```